### PR TITLE
update nickdollimount/xyplug-powershell to v1.0.3

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -117,7 +117,7 @@
 			"title": "PowerShell Plugin",
 			"author": "Nick Dollimount",
 			"description": "Execute PowerShell script code using xyOps events.",
-			"versions": ["v1.0.2", "v1.0.1", "v1.0.0"],
+			"versions": ["v1.0.3", "v1.0.1", "v1.0.0"],
 			"type": "plugin",
 			"plugin_type": "event",
 			"license": "MIT",


### PR DESCRIPTION
I broke the xyops.json syntax because I overwrote the entire file with what is copied from the UI (it doesn't have actually contain the full structure). I didn't notice until it threw an error when I tried to do the update in the UI after it was merged. So I've fixed that in v1.0.3. I removed v1.0.2 from the marketplace list as well so people don't accidentally manually try to install it as it's broken.