### PR TITLE
Added plugin xyOps 2 Confluence

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -237,6 +237,20 @@
 			"requires": ["pwsh"],
 			"created": "2026-02-16",
 			"modified": "2026-02-16"
+		},
+		{
+			"id": "talder/xyOps-ToConfluence",
+			"title": "Confluence Publisher",
+			"author": "Tim Alderweireldt",
+			"description": "A powerful xyOps Action Plugin that publishes Markdown content to Confluence Cloud pages with automatic ADF (Atlassian Document Format) conversion and image upload support.",
+			"versions": ["v1.0.0"],
+			"type": "plugin",
+			"plugin_type": "action",
+			"license": "MIT",
+			"tags": ["Confluence", "Atlassian", "Documentation"],
+			"requires": ["pwsh"],
+			"created": "2026-02-17",
+			"modified": "2026-02-17"
 		}
 	]
 }


### PR DESCRIPTION
Hi,

Just added another action plugin to export markdown documents to Atlassian Confluence pages for documentation. Has a bunch of features and nice examples and use cases. Hope you like it 😉

Grts,

Tim