### PR TITLE
Bumping xyOps-ToConfluence to version 1.2.2

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -243,14 +243,14 @@
 			"title": "Confluence Publisher",
 			"author": "Tim Alderweireldt",
 			"description": "A powerful xyOps Action Plugin that publishes Markdown content to Confluence Cloud pages with automatic ADF (Atlassian Document Format) conversion and image upload support.",
-			"versions": ["v1.0.0"],
+			"versions": ["v1.2.2"],
 			"type": "plugin",
 			"plugin_type": "action",
 			"license": "MIT",
 			"tags": ["Confluence", "Atlassian", "Documentation"],
 			"requires": ["pwsh"],
 			"created": "2026-02-17",
-			"modified": "2026-02-17"
+			"modified": "2026-02-20"
 		},
 		{
 			"id": "talder/xyOps-ToSyslog",

--- a/marketplace.json
+++ b/marketplace.json
@@ -265,6 +265,20 @@
 			"requires": ["pwsh"],
 			"created": "2026-02-17",
 			"modified": "2026-02-17"
+		},
+		{
+			"id": "talder/xyOps-Netbox-IPAM",
+			"title": "Netbox IPAM",
+			"author": "Tim Alderweireldt",
+			"description": "A comprehensive xyOps Event Plugin for managing IP Address Management (IPAM) in NetBox, including Prefixes, IP Addresses, VLANs, and VRFs.",
+			"versions": ["v1.3.0"],
+			"type": "plugin",
+			"plugin_type": "event",
+			"license": "MIT",
+			"tags": ["NetBox", "IPAM", "Network Automation"],
+			"requires": ["pwsh"],
+			"created": "2026-02-20",
+			"modified": "2026-02-20"
 		}
 	]
 }


### PR DESCRIPTION
## [1.2.2] - 2026-02-20

### Changed

#### Space ID Parameter (Breaking Change)
- **BREAKING CHANGE**: Renamed `spaceIdOrKey` parameter to `spaceId`
- **BREAKING CHANGE**: Only numeric Space IDs are now accepted (space keys like `DOCS` no longer work)
- This change aligns with Confluence Cloud REST API v2 requirements, which only support numeric IDs
- Updated documentation with instructions on how to find your numeric Space ID:
  - Via Confluence UI: Space Settings > Space Details
  - Via API: `GET /wiki/api/v2/spaces`
  - Via browser DevTools Network tab

## [1.2.1] - 2026-02-19

### Changed

#### Credentials moved to Environment Variables
- **BREAKING CHANGE**: Authentication credentials are now read from environment variables instead of plugin parameters
- Removed `confluenceUrl`, `email`, `apiToken`, `bearerToken` parameters from the UI
- New environment variables:
  - `CONFLUENCE_URL` - Base URL of your Confluence Cloud instance
  - `CONFLUENCE_EMAIL` - Email address for authentication
  - `CONFLUENCE_API_TOKEN` - Atlassian API token
  - `CONFLUENCE_BEARER_TOKEN` - Alternative OAuth bearer token
- Backwards compatibility maintained: plugin still checks parameters if environment variables are not set

## [1.2.0] - 2026-02-19

### Added

#### Update Mode Feature
- **New parameter `updateMode`** - Control how content is merged when updating existing pages:
  - `replace` - Replace entire page content (default, existing behavior)
  - `append` - Add new content at the end of the page
  - `prepend` - Add new content at the beginning of the page
  - `marker` - Insert content at a `{insert_here}` or `{insert_here:name=X}` marker
  - `section` - Replace content within `{replace_this:name=X}...{/replace_this}` tags

- **New parameter `markerName`** - Specify the name for markers or sections when using `marker` or `section` update modes

- **New function `Get-PageContentStorageFormat`** - Fetches existing page content in storage format for merging

- **New function `Merge-PageContent`** - Handles content merging logic for all update modes

### Changed

- Updated main flow to support content merging when updating pages (both ADF and Storage Format paths)
- Improved documentation with new "Mode vs Update Mode" section explaining the difference between the two settings
- Added comprehensive examples for all update modes in README.md

## [1.1.0] - 2026-02-18

### Added

#### Excerpt Support
- **New parameter `wrapInExcerpt`** - Checkbox to wrap entire content in a Confluence excerpt macro
- **New parameter `excerptName`** - Optional name for the excerpt when `wrapInExcerpt` is enabled
- **Excerpt tag support** - Parse `{excerpt}...{/excerpt}` and `{excerpt:name=Name}...{/excerpt}` tags in markdown
- **New function `Test-HasExcerpts`** - Detect excerpt tags in content
- **New function `Get-ExcerptNames`** - Extract excerpt names from content
- **New function `ConvertTo-StorageFormat`** - Convert markdown to Confluence Storage Format (XHTML)
- **New function `ConvertTo-StorageInline`** - Convert inline markdown elements to storage format
- **New function `New-ConfluencePageStorageFormat`** - Create pages using v1 API with storage format
- **New function `Update-ConfluencePageStorageFormat`** - Update pages using v1 API with storage format
- **New function `Get-PageByIdV1`** - Fetch page details using v1 API

### Changed

- Plugin automatically switches to Storage Format (v1 API) when excerpts are detected
- Updated README.md with excerpt documentation and examples